### PR TITLE
Revert "Bump jquery from 3.4.1 to 3.5.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2530,6 +2530,12 @@
           "integrity": "sha512-kPY94VCukPUPj+/6sZ9KvphD42KnpX2IS31p5z07OFVIviDogR0cQuld5c7Irzfgq7a0YACj0HlToROFn7dLYQ==",
           "dev": true
         },
+        "jquery": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+          "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+          "dev": true
+        },
         "path-parse": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
@@ -6245,7 +6251,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -15784,7 +15790,7 @@
       "dependencies": {
         "through": {
           "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/through/-/through-2.2.7.tgz",
           "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
           "dev": true
         }
@@ -15808,7 +15814,7 @@
       "dependencies": {
         "through": {
           "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/through/-/through-2.2.7.tgz",
           "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
           "dev": true
         }
@@ -15826,7 +15832,7 @@
       "dependencies": {
         "through": {
           "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/through/-/through-2.2.7.tgz",
           "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
           "dev": true
         }
@@ -15853,7 +15859,7 @@
       "dependencies": {
         "through": {
           "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/through/-/through-2.2.7.tgz",
           "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
           "dev": true
         }
@@ -15871,7 +15877,7 @@
       "dependencies": {
         "through": {
           "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/through/-/through-2.2.7.tgz",
           "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
           "dev": true
         }
@@ -16004,7 +16010,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -16899,9 +16905,9 @@
       }
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "js-reporters": {
       "version": "1.2.1",
@@ -17021,7 +17027,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
@@ -17141,7 +17147,7 @@
       "dependencies": {
         "through": {
           "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/through/-/through-2.2.7.tgz",
           "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
           "dev": true
         }
@@ -18674,7 +18680,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18739,7 +18745,7 @@
         },
         "inquirer": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
@@ -18760,13 +18766,13 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
         "ora": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+          "resolved": "http://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
           "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
           "dev": true,
           "requires": {


### PR DESCRIPTION
Reverts CleverCase/ember-bootstrap-controls#289